### PR TITLE
ボタンが表示されないバグを修正

### DIFF
--- a/hide.js
+++ b/hide.js
@@ -6,7 +6,7 @@ $("tbody").addClass("tbody1")
 $("table").after("<table class='stdlist' width='100%'><tbody class='tbody2'><tr class='title' no='0'><th class='top'>タイプ</th><th width='30%' class='top'>タイトル</th><th width='24%' class='top'>コース</th><th width='17%' class='top'>受付開始日時</th><th width='17%' class='top'>受付終了日時</th></tr></tbody></table>");
 $(".tbody2").parent("table").before("<h1 class='hideTitle'>隠した課題一覧   </h1>")
 $(".tbody2, .hideTitle").hide();
-$("table").eq(0).after("<button class='openExtentionButton' style='display: block; margin:10px 0 0 auto;'>拡張機能：Hide unsubmitted reports on Manaba を開く</button>");
+$(".pagebody table").eq(0).after("<button class='openExtentionButton' style='display: block; margin:10px 0 0 auto;'>拡張機能：Hide unsubmitted reports on Manaba を開く</button>");
 
 let deleteSet = new Set(JSON.parse(localStorage.getItem("chrome-extention-hide-unsubmitted-report-on-manaba")));
 


### PR DESCRIPTION
manabaの構造が変わったせいか、正常にボタンが表示されていませんでした。
そのため利用しているセレクタを最新版のmanabaで有効な要素になるように修正しました。

<table>
<tr>
    <td>Before:</td>
	<td><img width="909" alt="スクリーンショット 2022-12-06 16 17 31" src="https://user-images.githubusercontent.com/14256420/205847639-52a3af7f-f6f1-485b-ac9b-e2464369e83c.png"></td>
</tr>
<tr>
    <td>After:</td>
	<td><img width="862" alt="スクリーンショット 2022-12-06 16 18 49" src="https://user-images.githubusercontent.com/14256420/205847646-46ba168b-513f-47b1-8bb5-6ad74e188678.png"></td>
</tr>
</table>

